### PR TITLE
Solve: error in the calculation of properties using the thermochemical frozen approximation (calorically perfect gas) and minor bug in shockIncident method

### DIFF
--- a/+combustiontoolbox/+equilibrium/@EquilibriumSolver/equilibrate.m
+++ b/+combustiontoolbox/+equilibrium/@EquilibriumSolver/equilibrate.m
@@ -17,12 +17,6 @@ function mix2 = equilibrate(obj, mix2, varargin)
     
     % Initialization
     mix1 = mix2.copy();
-
-    if obj.FLAG_TCHEM_FROZEN
-        % TO BE IMPLEMENTED
-        mix2.errorProblem = 0;
-        return
-    end
     
     % Default
     mixGuess = [];

--- a/+combustiontoolbox/+equilibrium/@EquilibriumSolver/equilibrateT.m
+++ b/+combustiontoolbox/+equilibrium/@EquilibriumSolver/equilibrateT.m
@@ -128,6 +128,10 @@ function mix2 = equilibrateTPerfect(mix1, mix2, T)
     
     % Import packages
     import combustiontoolbox.common.Units
+    import combustiontoolbox.common.Constants
+
+    % Definitions
+    Tref = 298.15; % [K] To be fixed: each species should have its own reference temperature
 
     % Recompute properties of mix2
     setTemperature(mix2, T);
@@ -138,7 +142,24 @@ function mix2 = equilibrateTPerfect(mix1, mix2, T)
     mix2.gamma = mix1.gamma;
     mix2.gamma_s = mix1.gamma_s;
     mix2.sound = sqrt(mix2.gamma * Units.convert(mix2.p, 'bar', 'Pa') / mix2.rho);
+
+    % Compute enthalpy [J]
+    mix2.hf = mix1.hf;
+    mix2.DhT = mix1.cp * (T - Tref);
+    mix2.h = mix2.hf + mix2.DhT;
+
+    % Compute internal energy [J]
+    mix2.ef = mix1.ef;
+    mix2.DeT = mix1.cv * (T - Tref);
+    mix2.e = mix2.ef + mix2.DeT;
+
+    % Compute entropy [J/K]
+    mix2.s0 = mix1.s0 + mix1.cp * log(T / mix1.T);
+    mix2.s = mix2.s0 + mix2.Ds;
     
+    % Compute Gibbs free energy
+    mix2.g = mix2.h - T * mix2.s;
+
     if isempty(mix2.u)
         return
     end

--- a/+combustiontoolbox/+shockdetonation/@ShockSolver/shockIncident.m
+++ b/+combustiontoolbox/+shockdetonation/@ShockSolver/shockIncident.m
@@ -128,7 +128,7 @@ function [p2, T2, p2p1, T2T1] = get_guess(obj, mix1, mix2)
 
         if M1 > obj.machThermo
             % Estimate post-shock state considering h2 = h1 + u1^2 / 2
-            mix2.h = (mix1.h + mix1.u^2/2) * mix1.mi; % [J]
+            mix2.h = mix1.h + 0.5 * mix1.u^2 * mix1.mi; % [J]
 
             % Initialize mix2 and set pressure
             mix2.p = p2p1 * mix1.p;


### PR DESCRIPTION
Fix error in the calculation of enthalpy, internal energy, entropy, and Gibbs energy when using the calorically perfect gas approximation. Previously, these properties were computed directly from NASA polynomials, which account for temperature-dependent specific heat, enthalpy, entropy, and their derivatives. However, this approach is inconsistent with the calorically perfect gas assumption, where specific heat remains constant.

Now, these properties are determined by treating the mixture as a **thermochemically frozen state**, where temperature-dependent properties are evaluated based on the temperature difference relative to the reference temperature (typically 298.15 K). The thermochemically frozen components are obtained from the given mixture before any modifications, ensuring consistency with the calorically perfect gas model.