### PR TITLE
Add: include compact print for mixture composition #1025 and Update: check type of fluctuation in getEnergySpectra method from TurbulenceSpectra class

### DIFF
--- a/+combustiontoolbox/+turbulence/@TurbulenceSpectra/TurbulenceSpectra.m
+++ b/+combustiontoolbox/+turbulence/@TurbulenceSpectra/TurbulenceSpectra.m
@@ -92,6 +92,12 @@ classdef TurbulenceSpectra < handle
             % Example:
             %     [EK_avg, k] = getEnergySpectra(TurbulenceSpectra(), fluctuation);
 
+            % Check type of fluctuation
+            if isa(fluctuation, 'combustiontoolbox.turbulence.VelocityField')
+                [EK_avg, k] = getEnergySpectraVelocity(obj, fluctuation);
+                return
+            end
+
             % Check input
             assert(isnumeric(fluctuation), 'Input must be a 3D array.');
 


### PR DESCRIPTION
Now the `print` method within `Mixture` class allows to print its composition in a more compact way, as shown in the figure below.

![CleanShot 2025-03-05 at 09 02 25@2x](https://github.com/user-attachments/assets/52b569e2-52cb-4055-a229-e1cb2f9ff60b)
