### PR TITLE
Refactor `Mixture` class and optimize supporting functions  

### DIFF
--- a/+combustiontoolbox/+common/@Units/Units.m
+++ b/+combustiontoolbox/+common/@Units/Units.m
@@ -2,13 +2,30 @@ classdef Units < handle
     % Class with conversion factors between different units
     
     properties (Constant)
-        % Pressure
-        atm2bar = 1.01325      % Conversion factor from atm to bar
-        bar2atm = 1.01325^-1   % Conversion factor from bar to atm
-        atm2Pa  = 101325       % Conversion factor from atm to Pa
-        Pa2atm  = 101325^-1    % Conversion factor from Pa to atm
-        bar2Pa  = 1e5          % Conversion factor from bar to Pa
-        Pa2bar  = 1e-5         % Conversion factor from Pa to bar
+        % Pressure conversion factors
+        atm2bar = @(x) x * 1.01325     % Atmospheres to bar
+        bar2atm = @(x) x * 1.01325^-1  % Bar to atmospheres
+        atm2Pa  = @(x) x * 101325      % Atmospheres to Pascales
+        Pa2atm  = @(x) x * 101325^-1   % Pascales to atmospheres
+        bar2Pa  = @(x) x * 1e5         % Bar to Pascals
+        Pa2bar  = @(x) x * 1e-5        % Pascals to bar
+        % Temperature conversion factors
+        K2C     = @(x) x - 273.15      % Kelvin to degrees Celsius
+        C2K     = @(x) x + 273.15      % Degrees Celsius to Kelvin
+        F2C     = @(x) (x - 32) * 5/9  % Fahrenheit to degrees Celsius
+        K2F     = @(x) (x - 273.15) * 9/5 + 32 % Kelvin to Fahrenheit
+        % Mass conversion factors
+        kg2lbs  = @(x) x * 2.20462     % Kilograms to pounds
+        lbs2kg  = @(x) x * 0.453592    % Pounds to kilograms
+        kg2g    = @(x) x * 1e3         % Kilograms to grams
+        g2kg    = @(x) x * 1e-3        % Grams to kilograms
+        % Volume conversion factors
+        m32ft3  = @(x) x * 35.3147     % Cubic meters to cubic feet
+        ft32m3  = @(x) x * 35.3147^-1  % Cubic feet to cubic meters
+        m32L    = @(x) x * 1e3         % Cubic meters to liters
+        L2m3    = @(x) x * 1e-3        % Liters to cubic meters
+        ft32L   = @(x) x * 28.3168     % Cubic feet to liters
+        L2ft3   = @(x) x * 28.3168^-1  % Liters to cubic feet
     end
 
     methods (Static)
@@ -24,23 +41,27 @@ classdef Units < handle
             % Returns:
             %     value_out: Value converted to the output unit
             %
-            % Example:
-            %     Units.convert(1, 'atm', 'bar')
+            % Examples:
+            %     * Units.convert(1, 'atm', 'bar')
+            %     * Units.convert(273.15, 'K', 'C')
+            %     * Units.convert(1, 'kg', 'lbs')
+            %     * Units.convert(1, 'm3', 'ft3')
+            %     * Units.convert(1, 'm3', 'L')
             
             % Import packages
             import combustiontoolbox.common.Units
             
-            % Get the conversion factor property name
-            conversion_factor_name = [unit_in, '2', unit_out];
+            % Get the conversion key property name
+            conversionKey = [unit_in, '2', unit_out];
             
-            % Check conversion factor exist
-            assert(isprop(Units, conversion_factor_name), 'Conversion from %s to %s is not defined.', unit_in, unit_out); 
+            % Check conversion key exist
+            assert(isprop(Units, conversionKey), 'Conversion from %s to %s is not defined.', unit_in, unit_out); 
 
-            % Get the conversion factor
-            conversion_factor = Units.(conversion_factor_name);
+            % Get the conversion key value
+            conversion = Units.(conversionKey);
             
             % Convert the value
-            value_out = value_in * conversion_factor;
+            value_out = conversion(value_in);
         end
 
         function moles = convertWeightPercentage2moles(listSpecies, weightPercentage, database)

--- a/+combustiontoolbox/+common/@Units/Units.m
+++ b/+combustiontoolbox/+common/@Units/Units.m
@@ -3,29 +3,29 @@ classdef Units < handle
     
     properties (Constant)
         % Pressure conversion factors
-        atm2bar = @(x) x * 1.01325     % Atmospheres to bar
-        bar2atm = @(x) x * 1.01325^-1  % Bar to atmospheres
-        atm2Pa  = @(x) x * 101325      % Atmospheres to Pascales
-        Pa2atm  = @(x) x * 101325^-1   % Pascales to atmospheres
-        bar2Pa  = @(x) x * 1e5         % Bar to Pascals
-        Pa2bar  = @(x) x * 1e-5        % Pascals to bar
+        atm2bar = 1.01325     % Atmospheres to bar
+        bar2atm = 1.01325^-1  % Bar to atmospheres
+        atm2Pa  = 101325      % Atmospheres to Pascales
+        Pa2atm  = 101325^-1   % Pascales to atmospheres
+        bar2Pa  = 1e5         % Bar to Pascals
+        Pa2bar  = 1e-5        % Pascals to bar
         % Temperature conversion factors
         K2C     = @(x) x - 273.15      % Kelvin to degrees Celsius
         C2K     = @(x) x + 273.15      % Degrees Celsius to Kelvin
         F2C     = @(x) (x - 32) * 5/9  % Fahrenheit to degrees Celsius
         K2F     = @(x) (x - 273.15) * 9/5 + 32 % Kelvin to Fahrenheit
         % Mass conversion factors
-        kg2lbs  = @(x) x * 2.20462     % Kilograms to pounds
-        lbs2kg  = @(x) x * 0.453592    % Pounds to kilograms
-        kg2g    = @(x) x * 1e3         % Kilograms to grams
-        g2kg    = @(x) x * 1e-3        % Grams to kilograms
+        kg2lbs  = 2.20462     % Kilograms to pounds
+        lbs2kg  = 0.453592    % Pounds to kilograms
+        kg2g    = 1e3         % Kilograms to grams
+        g2kg    = 1e-3        % Grams to kilograms
         % Volume conversion factors
-        m32ft3  = @(x) x * 35.3147     % Cubic meters to cubic feet
-        ft32m3  = @(x) x * 35.3147^-1  % Cubic feet to cubic meters
-        m32L    = @(x) x * 1e3         % Cubic meters to liters
-        L2m3    = @(x) x * 1e-3        % Liters to cubic meters
-        ft32L   = @(x) x * 28.3168     % Cubic feet to liters
-        L2ft3   = @(x) x * 28.3168^-1  % Liters to cubic feet
+        m32ft3  = 35.3147     % Cubic meters to cubic feet
+        ft32m3  = 35.3147^-1  % Cubic feet to cubic meters
+        m32L    = 1e3         % Cubic meters to liters
+        L2m3    = 1e-3        % Liters to cubic meters
+        ft32L   = 28.3168     % Cubic feet to liters
+        L2ft3   = 28.3168^-1  % Liters to cubic feet
     end
 
     methods (Static)
@@ -54,13 +54,18 @@ classdef Units < handle
             % Get the conversion key property name
             conversionKey = [unit_in, '2', unit_out];
             
-            % Check conversion key exist
-            assert(isprop(Units, conversionKey), 'Conversion from %s to %s is not defined.', unit_in, unit_out); 
+            % Check conversion key exist (slow)
+            % assert(isprop(Units, conversionKey), 'Conversion from %s to %s is not defined.', unit_in, unit_out); 
 
             % Get the conversion key value
             conversion = Units.(conversionKey);
             
             % Convert the value
+            if ~ishandle(conversion)
+                value_out = value_in * conversion;
+                return
+            end
+            
             value_out = conversion(value_in);
         end
 

--- a/+combustiontoolbox/+core/@ChemicalSystem/ChemicalSystem.m
+++ b/+combustiontoolbox/+core/@ChemicalSystem/ChemicalSystem.m
@@ -25,6 +25,7 @@ classdef ChemicalSystem < handle & matlab.mixin.Copyable
         stoichiometricMatrix   % Stoichiometric matrix
         propertiesMatrix       % Properties matrix
         propertyVector         % Property vector
+        indexSpecies           % Index of species
         indexGas               % Indeces gaseous species
         indexCondensed         % Indeces condensed species
         indexCryogenic         % Indeces cryogenic liquified species
@@ -57,15 +58,6 @@ classdef ChemicalSystem < handle & matlab.mixin.Copyable
         numSpeciesGas % Number of gaseous species
         numElements   % Number of elements
         indexElements % Index of elements
-        indexSpecies  % Index of species
-        ind_C         % Index carbon
-        ind_H         % Index hydrogen
-        ind_O         % Index oxygen
-        ind_N         % Index nitrogen
-        ind_E         % Index electron
-        ind_S         % Index sulfur
-        ind_Si        % Index silicon
-        ind_B         % Index boron
     end
 
     properties (Hidden)
@@ -76,6 +68,14 @@ classdef ChemicalSystem < handle & matlab.mixin.Copyable
         indexProducts
         oxidizerReferenceIndex
         oxidizerReferenceAtomsO
+        ind_C         % Index carbon
+        ind_H         % Index hydrogen
+        ind_O         % Index oxygen
+        ind_N         % Index nitrogen
+        ind_E         % Index electron
+        ind_S         % Index sulfur
+        ind_Si        % Index silicon
+        ind_B         % Index boron
     end
     
     properties (Access = private, Hidden)
@@ -191,7 +191,7 @@ classdef ChemicalSystem < handle & matlab.mixin.Copyable
             % Update property matrix
             system.propertiesMatrix = system.propertiesMatrix(system.indexProducts, :);
 
-            % Update compostion matrix
+            % Update property vector
             system.propertyVector = system.propertyVector(system.indexProducts);
         end
 
@@ -261,38 +261,6 @@ classdef ChemicalSystem < handle & matlab.mixin.Copyable
 
         function value = get.numElements(obj)
             value = length(obj.listElements);
-        end
-
-        function value = get.ind_C(obj)
-            value = find(ismember(obj.listElements, 'C'));
-        end
-
-        function value = get.ind_H(obj)
-            value = find(ismember(obj.listElements, 'H'));
-        end
-
-        function value = get.ind_O(obj)
-            value = find(ismember(obj.listElements, 'O'));
-        end
-
-        function value = get.ind_N(obj)
-            value = find(ismember(obj.listElements, 'N'));
-        end
-
-        function value = get.ind_E(obj)
-            value = find(ismember(obj.listElements, 'E'));
-        end
-
-        function value = get.ind_S(obj)
-            value = find(ismember(obj.listElements, 'S'));
-        end
-
-        function value = get.ind_Si(obj)
-            value = find(ismember(obj.listElements, 'SI'));
-        end
-
-        function value = get.ind_B(obj)
-            value = find(ismember(obj.listElements, 'B'));
         end
     
         function value = get.indexSpecies(obj)
@@ -442,7 +410,7 @@ classdef ChemicalSystem < handle & matlab.mixin.Copyable
         
             if equivalenceRatio < 1
                 listSpecies = obj.listSpeciesLean;
-            elseif equivalenceRatio >= 1 && equivalenceRatio < equivalenceRatioSoot
+            elseif equivalenceRatio >= 1 && equivalenceRatio <= equivalenceRatioSoot
                 listSpecies = obj.listSpeciesRich;
             else
                 listSpecies = obj.listSpeciesSoot;
@@ -465,6 +433,7 @@ classdef ChemicalSystem < handle & matlab.mixin.Copyable
         
             obj = obj.setIndexPhaseSpecies();
             obj.listSpecies = obj.listSpecies([obj.indexGas, obj.indexCondensed]);
+
             % Reorginize index of gaseous, condensed and cryogenic species
             obj = obj.sortIndexPhaseSpecies();
         end
@@ -591,6 +560,16 @@ classdef ChemicalSystem < handle & matlab.mixin.Copyable
             end
         
             obj.listElements = unique(L_formula);
+
+            % Get index of elements (equivalence ratio)
+            obj.ind_C = find(ismember(obj.listElements, 'C'));
+            obj.ind_H = find(ismember(obj.listElements, 'H'));
+            obj.ind_O = find(ismember(obj.listElements, 'O'));
+            obj.ind_N = find(ismember(obj.listElements, 'N'));
+            obj.ind_E = find(ismember(obj.listElements, 'E'));
+            obj.ind_S = find(ismember(obj.listElements, 'S'));
+            obj.ind_Si = find(ismember(obj.listElements, 'SI'));
+            obj.ind_B = find(ismember(obj.listElements, 'B'));
         end
 
         function index = getIndexIons(obj, species)
@@ -651,6 +630,9 @@ classdef ChemicalSystem < handle & matlab.mixin.Copyable
         
             % Get index of ions
             obj.indexIons = obj.getIndexIons(obj.listSpecies);
+
+            % Get index of species
+            obj.indexSpecies = [obj.indexGas, obj.indexCondensed];
         end        
 
         function obj = sortIndexPhaseSpecies(obj)
@@ -662,9 +644,15 @@ classdef ChemicalSystem < handle & matlab.mixin.Copyable
             %
             % Returns:
             %     obj (ChemicalSystem): ChemicalSystem object with the index of gaseous, condensed and cryogenic species sorted
-        
+            
+            % Initialization
             obj.indexGas = []; obj.indexCondensed = []; obj.indexCryogenic = [];
+
+            % Get index of gaseous, condensed and cryogenic species
             obj = obj.setIndexPhaseSpecies();
+            
+            % Get index of species
+            obj.indexSpecies = [obj.indexGas, obj.indexCondensed];
         end
 
         function obj = setStoichiometricMatrix(obj)

--- a/+combustiontoolbox/+core/@ChemicalSystem/ChemicalSystem.m
+++ b/+combustiontoolbox/+core/@ChemicalSystem/ChemicalSystem.m
@@ -321,14 +321,14 @@ classdef ChemicalSystem < handle & matlab.mixin.Copyable
             %     T (float): Temperature [K]
             %
             % Optional Args:
-            %     ind (float): Vector with the indexes of the species to fill the properties matrix   
+            %     index (float): Vector with the indexes of the species to fill the properties matrix   
             %
             % Returns:
             %     obj (ChemicalSystem): ChemicalSystem object with the properties matrix filled
             %
             % Examples:
-            %     setPropertiesMatrix(obj, {'N2', 'O2'}, [3.76, 1], 300)
-            %     setPropertiesMatrix(obj, {'N2', 'O2'}, [3.76, 1], 300, [1, 2])
+            %     * setPropertiesMatrix(obj, {'N2', 'O2'}, [3.76, 1], 300)
+            %     * setPropertiesMatrix(obj, {'N2', 'O2'}, [3.76, 1], 300, [1, 2])
             
             % Fill properties matrix
             if nargin < 5
@@ -336,13 +336,89 @@ classdef ChemicalSystem < handle & matlab.mixin.Copyable
                 return
             elseif nargin < 6
                 index = varargin{1};
-                obj.propertiesMatrix = obj.fillPropertiesMatrixFast(obj, obj.propertiesMatrix, species(index), moles, T, index);
+                obj.propertiesMatrix = obj.fillPropertiesMatrixFast(obj, obj.propertiesMatrix, species(index), moles(index), T, index);
                 return
             end
     
             index = varargin{1};
             h0 = varargin{2};
-            obj.propertiesMatrix = obj.fillPropertiesMatrixFastH0(obj, obj.propertiesMatrix, species(index), moles, T, index, h0);
+            obj.propertiesMatrix = obj.fillPropertiesMatrixFastH0(obj, obj.propertiesMatrix, species(index), moles(index), T, index, h0(index));
+        end
+
+        function obj = setPropertiesMatrixInitialIndex(obj, species, moles, T, index, varargin)
+            % Fill the properties matrix with the data of the mixture
+            %
+            % Args:
+            %     obj (ChemicalSystem): ChemicalSystem object
+            %     species (cell): Species contained in the system
+            %     moles (float): Moles of the species in the mixture [mol]
+            %     T (float): Temperature [K]
+            %     index (float): Vector with the indexes of the species to fill the properties matrix   
+            %
+            % Returns:
+            %     obj (ChemicalSystem): ChemicalSystem object with the properties matrix filled
+            %
+            % Examples:
+            %     * setPropertiesMatrix(obj, {'N2', 'O2'}, [3.76, 1], 300)
+            %     * setPropertiesMatrix(obj, {'N2', 'O2'}, [3.76, 1], 300, [1, 2])
+            
+            % Fill properties matrix
+            if nargin < 6
+                obj.propertiesMatrix = obj.fillPropertiesMatrixFast(obj, obj.propertiesMatrix, species, moles, T, index);
+                return
+            end
+   
+            h0 = varargin{1};
+            obj.propertiesMatrix = obj.fillPropertiesMatrixFastH0(obj, obj.propertiesMatrix, species, moles, T, index, h0);
+        end
+
+        function obj = setPropertiesMatrixComposition(obj, species, moles, varargin)
+            % Fill the properties matrix with the data of the mixture
+            %
+            % Args:
+            %     obj (ChemicalSystem): ChemicalSystem object
+            %     species (cell): Species contained in the system
+            %     moles (float): Moles of the species in the mixture [mol]
+            %     T (float): Temperature [K]
+            %
+            % Optional Args:
+            %     index (float): Vector with the indexes of the species to fill the properties matrix   
+            %
+            % Returns:
+            %     obj (ChemicalSystem): ChemicalSystem object with the properties matrix filled
+            %
+            % Examples:
+            %     * setPropertiesMatrixComposition(obj, {'N2', 'O2'}, [3.76, 1])
+            %     * setPropertiesMatrixComposition(obj, {'N2', 'O2'}, [3.76, 1], [1, 2])
+            
+            % Fill properties matrix
+            if nargin < 4
+                obj.propertiesMatrix = obj.fillPropertiesMatrixComposition(obj, obj.propertiesMatrix, species, moles);
+                return
+            end
+
+            index = varargin{1};
+            obj.propertiesMatrix = obj.fillPropertiesMatrixCompositionFast(obj, obj.propertiesMatrix, species(index), moles(index), index);
+        end
+
+        function obj = setPropertiesMatrixCompositionInitialIndex(obj, species, moles, index)
+            % Fill the properties matrix with the data of the mixture
+            %
+            % Args:
+            %     obj (ChemicalSystem): ChemicalSystem object
+            %     species (cell): Species contained in the system
+            %     moles (float): Moles of the species in the mixture [mol]
+            %     T (float): Temperature [K]
+            %     index (float): Vector with the indexes of the species to fill the properties matrix   
+            %
+            % Returns:
+            %     obj (ChemicalSystem): ChemicalSystem object with the properties matrix filled
+            %
+            % Example:
+            %     setPropertiesMatrixCompositionInitialIndex(obj, {'N2', 'O2'}, [3.76, 1], [1, 2])
+            
+            % Fill properties matrix
+            obj.propertiesMatrix = obj.fillPropertiesMatrixCompositionFast(obj, obj.propertiesMatrix, species, moles, index);
         end
 
         function obj = clean(obj)
@@ -359,9 +435,6 @@ classdef ChemicalSystem < handle & matlab.mixin.Copyable
             % Check if the list of species corresponds to "complete_reaction"
             % If FLAG_COMPLETE is true, establish the list of species based on the
             % given equivalence ratio (phi)
-
-            % Import packages
-            import combustiontoolbox.utils.findIndex
             
             if ~obj.FLAG_COMPLETE
                 return
@@ -375,7 +448,7 @@ classdef ChemicalSystem < handle & matlab.mixin.Copyable
                 listSpecies = obj.listSpeciesSoot;
             end
         
-            obj.indexProducts = findIndex(obj.listSpecies, listSpecies);
+            obj.indexProducts = combustiontoolbox.utils.findIndex(obj.listSpecies, listSpecies);
             obj = obj.sortIndexPhaseSpecies();
         end
 
@@ -405,9 +478,6 @@ classdef ChemicalSystem < handle & matlab.mixin.Copyable
             %
             % Returns:
             %     obj (ChemicalSystem): ChemicalSystem object with the index of react and frozen species
-            
-            % Import packages
-            import combustiontoolbox.utils.findIndex
 
             % Initialization
             obj.indexReact = 1:obj.numSpecies;
@@ -419,7 +489,7 @@ classdef ChemicalSystem < handle & matlab.mixin.Copyable
             end
             
             % Get index frozen species
-            index = findIndex(obj.listSpecies, speciesFrozen);
+            index = combustiontoolbox.utils.findIndex(obj.listSpecies, speciesFrozen);
 
             % Set index frozen species
             obj.indexFrozen = index;
@@ -669,12 +739,9 @@ classdef ChemicalSystem < handle & matlab.mixin.Copyable
             %
             % Returns:
             %     propertiesMatrix (float): Properties matrix filled
-            
-            % Import packages
-            import combustiontoolbox.utils.findIndex
 
             % Get index species
-            index = findIndex(obj.listSpecies, species);
+            index = combustiontoolbox.utils.findIndex(obj.listSpecies, species);
 
             % Fill properties matrix
             propertiesMatrix(index, obj.ind_ni) = moles; % [mol]
@@ -701,7 +768,7 @@ classdef ChemicalSystem < handle & matlab.mixin.Copyable
             % Returns:
             %     propertiesMatrix (float): Properties matrix filled
 
-            propertiesMatrix(index, obj.ind_ni) = moles(index); % [mol]
+            propertiesMatrix(index, obj.ind_ni) = moles; % [mol]
             
             % for i = length(index):-1:1
             %     propertiesMatrix(index(i), obj.ind_hi) = obj.species.(species{i}).get_h0(T); % [J/mol]
@@ -732,14 +799,49 @@ classdef ChemicalSystem < handle & matlab.mixin.Copyable
             % Returns:
             %     propertiesMatrix (float): Properties matrix filled
 
-            propertiesMatrix(index, obj.ind_ni) = moles(index); % [mol]
-            propertiesMatrix(index, obj.ind_hi) = h0(index); % [J/mol]
+            propertiesMatrix(index, obj.ind_ni) = moles; % [mol]
+            propertiesMatrix(index, obj.ind_hi) = h0; % [J/mol]
 
             for i = length(index):-1:1
                 propertiesMatrix(index(i), obj.ind_cpi) = getHeatCapacityPressure(obj.species.(species{i}), T); % [J/mol-K]
                 propertiesMatrix(index(i), obj.ind_si) = getEntropy(obj.species.(species{i}), T); % [J/mol-K]
             end
 
+        end
+
+        function propertiesMatrix = fillPropertiesMatrixComposition(obj, propertiesMatrix, species, moles)
+            % Fill the properties matrix with the data of the mixture
+            %
+            % Args:
+            %     obj (ChemicalSystem): ChemicalSystem object
+            %     propertiesMatrix (float): Properties matrix
+            %     species (cell): Species contained in the system
+            %     moles (float): Moles of the species in the mixture [mol]
+            %
+            % Returns:
+            %     propertiesMatrix (float): Properties matrix filled
+
+            % Get index species
+            index = combustiontoolbox.utils.findIndex(obj.listSpecies, species);
+
+            % Fill properties matrix
+            propertiesMatrix(index, obj.ind_ni) = moles; % [mol]
+        end
+            
+        function propertiesMatrix = fillPropertiesMatrixCompositionFast(obj, propertiesMatrix, species, moles, index)
+            % Fill properties matrix with the data of the mixture
+            %
+            % Args:
+            %     obj (ChemicalSystem): ChemicalSystem object
+            %     propertiesMatrix (float): Properties matrix
+            %     species (cell): Species contained in the system
+            %     moles (float): Moles of the species in the mixture [mol]
+            %     index (float): Vector with the indexes of the species to fill the properties matrix
+            %
+            % Returns:
+            %     propertiesMatrix (float): Properties matrix filled
+
+            propertiesMatrix(index, obj.ind_ni) = moles; % [mol]
         end
 
     end

--- a/+combustiontoolbox/+core/@Mixture/Mixture.m
+++ b/+combustiontoolbox/+core/@Mixture/Mixture.m
@@ -634,7 +634,7 @@ classdef Mixture < handle & matlab.mixin.Copyable
                 % Compute pressure in Pascals using the equationState
                 pressure = obj.equationState.getPressure(obj.T, vMolar, obj.chemicalSystem.listSpecies, obj.quantity / sum(obj.quantity)); % [Pa]
                 % Convert pressure to [bar]
-                obj.p = combustiontoolbox.common.Units.convert(pressure, 'Pa', 'bar');
+                obj.p = pressure * combustiontoolbox.common.Units.Pa2bar;
             end
             
             % Assign values to the propertiesMatrix
@@ -865,7 +865,7 @@ classdef Mixture < handle & matlab.mixin.Copyable
             
             % Compute volume [m3]
             if N_gas
-                obj.v = obj.equationState.getVolume(temperature, combustiontoolbox.common.Units.convert(pressure, 'bar', 'Pa'), obj.chemicalSystem.listSpecies, obj.Xi) * N_gas;
+                obj.v = obj.equationState.getVolume(temperature, pressure * combustiontoolbox.common.Units.bar2Pa, obj.chemicalSystem.listSpecies, obj.Xi) * N_gas;
             else
                 % Mixture that only has condensed species
                 obj.v = obj.vSpecific * obj.mi;
@@ -920,7 +920,7 @@ classdef Mixture < handle & matlab.mixin.Copyable
                     obj.gamma_s = -obj.gamma / obj.dVdp_T;
 
                     % Compute sound velocity [m/s]
-                    obj.sound = sqrt(obj.gamma_s * combustiontoolbox.common.Units.convert(pressure, 'bar', 'Pa') / obj.rho); % [m/s]
+                    obj.sound = sqrt(obj.gamma_s * pressure * combustiontoolbox.common.Units.bar2Pa / obj.rho); % [m/s]
 
                     % Compute Mach number
                     if ~isempty(obj.u)
@@ -950,7 +950,7 @@ classdef Mixture < handle & matlab.mixin.Copyable
             obj.gamma_s = obj.gamma;
 
             % Compute sound velocity [m/s]
-            obj.sound = sqrt(obj.gamma * combustiontoolbox.common.Units.convert(pressure, 'bar', 'Pa') / obj.rho);
+            obj.sound = sqrt(obj.gamma * combustiontoolbox.common.Units.bar2Pa / obj.rho);
             
             % Compute Mach number
             if ~isempty(obj.u)
@@ -1058,21 +1058,13 @@ classdef Mixture < handle & matlab.mixin.Copyable
             % Returns:
             %     obj (Mixture): Mixture object with updated atomic counts for the fuel
             
-            % List of elements to assign (extend this list as needed)
-            elements = {'C', 'H',  'O', 'N', 'S', 'Si', 'B'};
-            coeffVec = [  1, 1/4, -1/2,   0,   1,    1, 3/4];
-            
-            for i = 1:length(elements)
-                elem = elements{i};
-                indexField = ['ind_' elem];
-
-                if isprop(obj.chemicalSystem, indexField) && ~isempty(obj.chemicalSystem.(indexField))
-                    obj.fuel.(elem) = natomElementsFuel(obj.chemicalSystem.(indexField));
-                    continue
-                end
-
-                obj.fuel.(elem) = 0;
-            end
+            if isempty(obj.chemicalSystem.ind_C), obj.fuel.C = 0; else, obj.fuel.C = natomElementsFuel(obj.chemicalSystem.ind_C); end
+            if isempty(obj.chemicalSystem.ind_H), obj.fuel.H = 0; else, obj.fuel.H = natomElementsFuel(obj.chemicalSystem.ind_H); end
+            if isempty(obj.chemicalSystem.ind_O), obj.fuel.O = 0; else, obj.fuel.O = natomElementsFuel(obj.chemicalSystem.ind_O); end
+            if isempty(obj.chemicalSystem.ind_N), obj.fuel.N = 0; else, obj.fuel.N = natomElementsFuel(obj.chemicalSystem.ind_N); end
+            if isempty(obj.chemicalSystem.ind_S), obj.fuel.S = 0; else, obj.fuel.S = natomElementsFuel(obj.chemicalSystem.ind_S); end
+            if isempty(obj.chemicalSystem.ind_Si), obj.fuel.Si = 0; else, obj.fuel.Si = natomElementsFuel(obj.chemicalSystem.ind_Si); end
+            if isempty(obj.chemicalSystem.ind_B), obj.fuel.B = 0; else, obj.fuel.B = natomElementsFuel(obj.chemicalSystem.ind_B); end
 
         end
 

--- a/+combustiontoolbox/+core/@Mixture/Mixture.m
+++ b/+combustiontoolbox/+core/@Mixture/Mixture.m
@@ -77,43 +77,41 @@ classdef Mixture < handle & matlab.mixin.Copyable
     end
 
     properties (Access = private)
-        indexGas              % Index of the gas species
-        Tspecies              % Species-specific initial temperatures [K]
-        FLAG_TSPECIES = false % Flag to indicate species-specific initial temperatures are defined
-        FLAG_VOLUME = false   % Flag to indicate specific volume is defined
+        indexSpecies           % Index of the species (initial mixture)
+        indexGas               % Index of the gas species (initial mixture)
+        Tspecies               % Species-specific initial temperatures [K] (initial mixture)
+        FLAG_TSPECIES = false  % Flag to indicate species-specific initial temperatures are defined (initial mixture)
+        FLAG_VOLUME = false    % Flag to indicate specific volume is defined (initial mixture)
     end
     
     properties (Hidden)
-        errorMoles            % Relative error in the moles calculation [-]
-        errorMolesIons        % Relative error in the moles of ions calculation [-]
-        errorProblem          % Relative error in the problem [-]
-        cp_f
-        cp_r
-        dNi_T
-        dN_T
-        dNi_p
-        dN_p
-        quantity
-        listSpecies
-        listSpeciesFuel
-        listSpeciesOxidizer
-        listSpeciesInert
-        molesFuel
-        molesOxidizer
-        molesInert
-        chemicalSystemProducts
-        problemType
-        fuel
-        rangeName
-        ratioOxidizer % Ratio oxidizer relative to the oxidizer of reference
-        FLAG_FUEL = false
-        FLAG_OXIDIZER = false
-        FLAG_INERT = false
-        FLAG_REACTION = false
-    end
-
-    properties (Hidden, Dependent)
-        numSpecies % Number of species in the reactant mixture
+        errorMoles = 0         % Relative error in the moles calculation [-]
+        errorMolesIons = 0     % Relative error in the moles of ions calculation [-]
+        errorProblem = 0       % Relative error in the problem [-]
+        cp_f                   % Frozen component of the specific heat at constant pressure
+        cp_r                   % Reactive component of the specific heat at constant pressure
+        dNi_T                  % Partial derivative of the number of moles with respect to temperature
+        dN_T                   % Partial derivative of the total number of moles with respect to temperature
+        dNi_p                  % Partial derivative of the number of moles with respect to pressure
+        dN_p                   % Partial derivative of the total number of moles with respect to pressure
+        chemicalSystemProducts % Chemical system containing only the list of products
+        problemType            % Problem type
+        rangeName              % Parametric property name
+        quantity               % Composition (initial mixture)
+        numSpecies             % Number of species (initial mixture)
+        listSpecies            % List of species (initial mixture)
+        listSpeciesFuel        % List of species fuel (initial mixture)
+        listSpeciesOxidizer    % List of species oxidizer (initial mixture)
+        listSpeciesInert       % List of species inert (initial mixture)
+        molesFuel              % Moles of fuel (initial mixture)
+        molesOxidizer          % Moles of oxidizer (initial mixture)
+        molesInert             % Moles of inert (initial mixture)
+        ratioOxidizer          % Ratio oxidizer relative to the oxidizer of reference (initial mixture)
+        fuel                   % Fuel atoms (initial mixture)
+        FLAG_FUEL = false      % Flag to indicate fuel species are defined (initial mixture)
+        FLAG_OXIDIZER = false  % Flag to indicate oxidizer species are defined (initial mixture)
+        FLAG_INERT = false     % Flag to indicate inert species are defined (initial mixture)
+        FLAG_REACTION = false  % Flag to indicate chemical reaction is defined
     end
     
     methods
@@ -147,11 +145,6 @@ classdef Mixture < handle & matlab.mixin.Copyable
             obj.config = ip.Results.config;
         end
 
-        function numSpecies = get.numSpecies(obj)
-            % Get number of species in the reactant mixture
-            numSpecies = length(obj.listSpecies);
-        end
-
         function obj = setTemperature(obj, T, varargin)
             % Set temperature [K] and compute thermodynamic properties
             %
@@ -182,14 +175,8 @@ classdef Mixture < handle & matlab.mixin.Copyable
             % Assign temperature
             obj.T = T;
             
-            % Set equivalence ratio and compute thermodynamic properties
-            if ~isempty(obj.equivalenceRatio)
-                setEquivalenceRatio(obj, obj.equivalenceRatio);
-                return
-            end
-            
             % Update thermodynamic state
-            updateState(obj);
+            updateThermodynamics(obj);
         end
 
         function obj = setPressure(obj, p, varargin)
@@ -221,15 +208,9 @@ classdef Mixture < handle & matlab.mixin.Copyable
 
             % Assign pressure
             obj.p = p;
-            
-            % Set equivalence ratio and compute thermodynamic properties
-            if ~isempty(obj.equivalenceRatio)
-                setEquivalenceRatio(obj, obj.equivalenceRatio);
-                return
-            end
 
             % Update thermodynamic state
-            updateState(obj);
+            updateThermodynamics(obj);
         end
 
         function obj = setVolume(obj, vSpecific, varargin)
@@ -262,31 +243,9 @@ classdef Mixture < handle & matlab.mixin.Copyable
             % Assign specific volume
             obj.vSpecific = vSpecific;
             obj.FLAG_VOLUME = true;
-
-            % Check if initial state is defined (temperature, pressure, and composition)
-            if ~sum(obj.quantity) || ~obj.T
-                return
-            end
             
-            % Compute pressure
-            vMolar = vSpecific2vMolar(obj, obj.vSpecific, obj.quantity, obj.quantity(obj.indexGas));
-            pressure = obj.equationState.getPressure(obj.T, vMolar, obj.chemicalSystem.listSpecies, obj.quantity / sum(obj.quantity)); % [Pa]
-            obj.p = Units.convert(pressure, 'Pa', 'bar');
-
-            % Set equivalence ratio and compute thermodynamic properties
-            if ~isempty(obj.equivalenceRatio)
-                setEquivalenceRatio(obj, obj.equivalenceRatio);
-                return
-            end
-
-            % Assign values to the propertiesMatrix
-            obj.chemicalSystem.setPropertiesMatrix(obj.listSpecies, obj.quantity, obj.T);
-
-            % Compute thermodynamic properties
-            computeProperties(obj);
-
-            % Compute equivalence ratio, percentage Fuel, and Oxidizer/Fuel ratio
-            computeEquivalenceRatio(obj);
+            % Update thermodynamic state
+            updateThermodynamics(obj);
         end
 
         function obj = set(obj, listSpecies, varargin)
@@ -354,50 +313,31 @@ classdef Mixture < handle & matlab.mixin.Copyable
                 quantity = varargin{1};
             end
 
-            % Update local listSpecies and local quantity
+            % Update listSpecies, quantity and numSpecies of the initial mixture
             obj.listSpecies = [obj.listSpecies, listSpecies];
             obj.quantity = [obj.quantity, quantity];
-            
+            obj.numSpecies = length(obj.listSpecies);
+
             % Check if species are contained in the chemical system
             obj.chemicalSystem.checkSpecies(listSpecies);
             
-            % Get indexReact
+            % Get index species in the mixture
+            obj.indexSpecies = findIndex(obj.chemicalSystem.listSpecies, obj.listSpecies);
+
+            % Get index react species
             obj.chemicalSystem.setReactIndex(obj.listSpeciesInert);
             
-            % Get indexProducts
+            % Get index products species
             obj.chemicalSystem.indexProducts = findIndex(obj.chemicalSystem.listSpecies, obj.chemicalSystem.listProducts);
-
-            % Get system containing only the list of products
-            obj.chemicalSystemProducts = getSystemProducts(obj.chemicalSystem);
             
-            % Check phase added species
+            % Get index gas species
             obj.indexGas = find(ismember(obj.listSpecies, obj.chemicalSystem.listSpecies(obj.chemicalSystem.indexGas)));
 
-            % Check if initial state is defined (temperature, pressure, and composition)
-            if ~obj.T || (~obj.p && ~obj.vSpecific)
-                return
-            end
+            % Update composition
+            updateComposition(obj);
 
-            % Compute pressure if required
-            if obj.vSpecific && obj.FLAG_VOLUME
-                vMolar = vSpecific2vMolar(obj, obj.vSpecific, obj.quantity, obj.quantity(obj.indexGas));
-                obj.p = convert_Pa_to_bar(obj.equationState.getPressure(obj.T, vMolar, obj.chemicalSystem.listSpecies, obj.quantity / sum(obj.quantity)));
-            end
-
-            % Set equivalence ratio and compute thermodynamic properties
-            if ~isempty(obj.equivalenceRatio)
-                setEquivalenceRatio(obj, obj.equivalenceRatio);
-                return
-            end
-            
-            % Assign values to the propertiesMatrix
-            obj.chemicalSystem.setPropertiesMatrix(listSpecies, quantity, obj.T);
-
-            % Compute thermodynamic properties
-            computeProperties(obj);
-            
-            % Compute percentage Fuel, Oxidizer/Fuel ratio and equivalence ratio
-            computeEquivalenceRatio(obj);
+            % Update thermodynamic state
+            updateThermodynamics(obj);
         end
 
         function obj = setEquivalenceRatio(obj, equivalenceRatio)
@@ -413,58 +353,14 @@ classdef Mixture < handle & matlab.mixin.Copyable
             % Example:
             %     setEquivalenceRatio(obj, 1)
 
+            % Definitions
             obj.equivalenceRatio = equivalenceRatio;
             
-            % Check if initial state is defined (temperature, pressure, and composition)
-            if ~obj.T || (~obj.p && ~obj.vSpecific) || ~obj.FLAG_FUEL || ~obj.FLAG_OXIDIZER
-                return
-            end
-            
-            % Set oxidizer of reference
-            obj.chemicalSystem.setOxidizerReference(obj.listSpeciesOxidizer);
-            
-            % Computation of theoretical stoichiometricMoles
-            obj.defineF();
-            
-            % Define moles Oxidizer 
-            if isempty(obj.ratioOxidizer), obj.ratioOxidizer = obj.molesOxidizer; end
-            obj.molesOxidizer = obj.stoichiometricMoles / obj.equivalenceRatio .* obj.ratioOxidizer;
-            
-            % Define oxidizer propertiesMatrix
-            obj.defineO();
-
-            % Update listSpecies and quantity
-            obj.listSpecies = [obj.listSpeciesFuel, obj.listSpeciesOxidizer, obj.listSpeciesInert];
-            obj.quantity = [obj.molesFuel, obj.molesOxidizer, obj.molesInert];
-            
-            % Assign values to the propertiesMatrix
-            obj.chemicalSystem = obj.chemicalSystem.setPropertiesMatrix(obj.listSpecies, obj.quantity, obj.T);
-            
-            % Compute equilibrium temperature if species-specific initial temperatures are defined
-            if obj.FLAG_TSPECIES
-                obj.setTemperatureSpecies(obj.Tspecies);
-                % Reset species-specific temperatures 
-                obj.Tspecies = [];
-                obj.FLAG_TSPECIES = false;
-            end
-
-            % Compute pressure if required
-            if obj.vSpecific && obj.FLAG_VOLUME
-                vMolar = vSpecific2vMolar(obj, obj.vSpecific, obj.quantity, obj.quantity(obj.indexGas));
-                obj.p = convert_Pa_to_bar(obj.equationState.getPressure(obj.T, vMolar, obj.chemicalSystem.listSpecies, obj.quantity / sum(obj.quantity)));
-            end
+            % Update composition
+            updateComposition(obj);
 
             % Compute thermodynamic properties
-            computeProperties(obj);
-            
-            % Compute percentage Fuel, Oxidizer/Fuel ratio and equivalence ratio
-            obj.computeRatiosFuelOxidizer(obj.chemicalSystem.propertiesMatrixFuel, obj.chemicalSystem.propertiesMatrixOxidizer);
-
-            % Check complete combustion
-            checkCompleteReaction(obj.chemicalSystem, obj.equivalenceRatio, obj.equivalenceRatioSoot);
-            
-            % Get system containing only the list of products
-            obj.chemicalSystemProducts = getSystemProducts(obj.chemicalSystem);
+            updateThermodynamics(obj);
         end
 
         function obj = setTemperatureSpecies(obj, speciesTemperatures)
@@ -504,7 +400,7 @@ classdef Mixture < handle & matlab.mixin.Copyable
             %     obj (Mixture): Mixture object with updated equivalence ratio [-]
             
             % Check if initial state is defined (temperature, pressure, and composition)
-            if ~obj.T || (~obj.p && ~obj.vSpecific) || ~obj.FLAG_FUEL || ~obj.FLAG_OXIDIZER
+            if ~obj.FLAG_FUEL || ~obj.FLAG_OXIDIZER
                 return
             end
 
@@ -684,6 +580,7 @@ classdef Mixture < handle & matlab.mixin.Copyable
                             objArray(j).FLAG_VOLUME = true;
                         case {'equivalenceratio', 'phi'}
                             objArray(j).equivalenceRatio = values{i}(j);
+                            objArray(j).updateComposition();
                         case {'velocity', 'u', 'u1'}
                             objArray(j).u = values{i}(j);
                         case {'mach', 'm1'}
@@ -705,8 +602,8 @@ classdef Mixture < handle & matlab.mixin.Copyable
 
                 end
 
-                % Compute state
-                objArray(j).setTemperature(objArray(j).T);
+                % Compute thermodynamic state of the mixture
+                objArray(j).updateThermodynamics();
 
                 % Additional inputs
                 if FLAG_MACH
@@ -717,8 +614,8 @@ classdef Mixture < handle & matlab.mixin.Copyable
 
         end
 
-        function obj = updateState(obj)
-            % Update the state of the mixture
+        function obj = updateThermodynamics(obj)
+            % Update the thermodynamic state of the mixture
             %
             % Args:
             %     obj (Mixture): Mixture object
@@ -737,29 +634,79 @@ classdef Mixture < handle & matlab.mixin.Copyable
                 % Compute pressure in Pascals using the equationState
                 pressure = obj.equationState.getPressure(obj.T, vMolar, obj.chemicalSystem.listSpecies, obj.quantity / sum(obj.quantity)); % [Pa]
                 % Convert pressure to [bar]
-                obj.p = combustiontoolbox.core.Units.convert(pressure, 'Pa', 'bar');
+                obj.p = combustiontoolbox.common.Units.convert(pressure, 'Pa', 'bar');
             end
             
             % Assign values to the propertiesMatrix
-            obj.chemicalSystem.setPropertiesMatrix(obj.listSpecies, obj.quantity, obj.T);
+            obj.chemicalSystem.setPropertiesMatrixInitialIndex(obj.listSpecies, obj.quantity, obj.T, obj.indexSpecies);
 
             % Compute thermodynamic properties
-            computeProperties(obj);
+            computeThermodynamics(obj);
+        end
 
-            % Compute equivalence ratio, percentage Fuel, and Oxidizer/Fuel ratio
+        function obj = updateComposition(obj)
+            % Update the composition of the mixture
+            %
+            % Args:
+            %     obj (Mixture): Mixture object
+            %
+            % Returns:
+            %     obj (Mixture): Mixture object with updated properties
+            
+            % Check if initial composition is defined
+            if ~sum(obj.quantity)
+                return
+            end
+
+            % Check if mixture is compound of a fuel and an oxidizer
+            if obj.FLAG_FUEL && obj.FLAG_OXIDIZER
+                % Set oxidizer of reference
+                obj.chemicalSystem.setOxidizerReference(obj.listSpeciesOxidizer);
+                
+                % Computation of theoretical stoichiometricMoles
+                obj.defineF();
+                
+                % Define moles Oxidizer
+                if ~isempty(obj.equivalenceRatio)
+                    if isempty(obj.ratioOxidizer), obj.ratioOxidizer = obj.molesOxidizer; end
+                    obj.molesOxidizer = obj.stoichiometricMoles / obj.equivalenceRatio .* obj.ratioOxidizer;
+                end
+
+                % Define oxidizer propertiesMatrix
+                obj.defineO();
+    
+                % Update quantity
+                obj.quantity = [obj.molesFuel, obj.molesOxidizer, obj.molesInert];
+            end
+            
+            % Assign values to the propertiesMatrix
+            obj.chemicalSystem.setPropertiesMatrixCompositionInitialIndex(obj.listSpecies, obj.quantity, obj.indexSpecies);
+
+            % Compute composition
+            computeComposition(obj);
+
+            % Compute equivalence ratio
             computeEquivalenceRatio(obj);
+
+            % Check complete combustion
+            if ~isempty(obj.equivalenceRatio)
+                checkCompleteReaction(obj.chemicalSystem, obj.equivalenceRatio, obj.equivalenceRatioSoot);
+            end
+            
+            % Get system containing only the list of products
+            obj.chemicalSystemProducts = getSystemProducts(obj.chemicalSystem);
         end
 
         function vMolar = vSpecific2vMolar(obj, vSpecific, moles, molesGas, varargin)
             % Compute molar volume [m3/mol] from specific volume [m3/kg]
-            
+
             % Get index specie
             if nargin == 4
                 index = combustiontoolbox.utils.findIndex(obj.chemicalSystem.listSpecies, obj.listSpecies);
             else
                 index = varargin{1};
             end
-
+            
             % Compute Mean Molecular Weight [kg/mol]
             MW = computeMeanMolecularWeight(obj, moles, index);
 
@@ -821,7 +768,7 @@ classdef Mixture < handle & matlab.mixin.Copyable
         % end
 
         function obj = computeProperties(obj)
-            % Compute thermodynamic properties of the mixture
+            % Compute composition and thermodynamic properties of the mixture
             %
             % Args:
             %     obj (Mixture): Mixture object
@@ -832,25 +779,23 @@ classdef Mixture < handle & matlab.mixin.Copyable
             % Example:
             %     mix = computeProperties(obj)
 
+            % Compute composition
+            computeComposition(obj);
+            
+            % Compute thermodynamic properties
+            computeThermodynamics(obj);
+        end
+
+        function computeComposition(obj)
+            % Compute the composition of the mixture
+
             % Definitions
-            temperature = obj.T;
-            pressure = obj.p;
-            R0 = combustiontoolbox.common.Constants.R0; % Universal gas constant [J/(K mol)]
             system = obj.chemicalSystem;
             propertiesMatrix = system.propertiesMatrix; % Properties matrix
-
-            % Initialization
-            obj.errorMoles = 0;
-            obj.errorMolesIons = 0;
 
             % Unpack propertiesMatrix
             Ni = propertiesMatrix(:, system.ind_ni); % [mol]
             obj.N = sum(propertiesMatrix(:, system.ind_ni)); % [mol]
-            obj.hf = dot(propertiesMatrix(:, system.ind_hfi), Ni); % [J]
-            obj.h = dot(propertiesMatrix(:, system.ind_hi), Ni); % [J]
-            obj.ef = dot(propertiesMatrix(:, system.ind_efi), Ni); % [J]
-            obj.cp = dot(propertiesMatrix(:, system.ind_cpi), Ni); % [J/K]
-            obj.s0 = dot(propertiesMatrix(:, system.ind_si), Ni); % [J/K]
             obj.phase = propertiesMatrix(:, system.ind_phase); % [bool]
 
             % Compute total composition of gas species [mol]
@@ -871,14 +816,52 @@ classdef Mixture < handle & matlab.mixin.Copyable
             % Compute mass fractions [-]
             obj.Yi = (Ni .* propertiesMatrix(:, system.ind_W)) ./ obj.mi;
 
-            % Get non zero species
-            FLAG_NONZERO = obj.Xi > 0;
-
             % Compute vector atoms of each element
             obj.natomElements = sum(Ni .* system.stoichiometricMatrix, 1);
 
             % Compute vector atoms of each element without frozen species
             obj.natomElementsReact = sum(propertiesMatrix(system.indexReact, system.ind_ni) .* system.stoichiometricMatrix(system.indexReact, :), 1);
+        end
+
+        function obj = computeThermodynamics(obj)
+            % Compute thermodynamic properties of the mixture
+            %
+            % Args:
+            %     obj (Mixture): Mixture object
+            %
+            % Returns:
+            %     obj (Mixture): Mixture object with the computed properties
+            %
+            % Example:
+            %     mix = computeThermodynamics(obj)
+
+            if obj.FLAG_TSPECIES
+                obj.setTemperatureSpecies(obj.Tspecies);
+                % Reset species-specific temperatures 
+                obj.Tspecies = [];
+                obj.FLAG_TSPECIES = false;
+            end
+            
+            % Definitions
+            temperature = obj.T;
+            pressure = obj.p;
+            R0 = combustiontoolbox.common.Constants.R0; % Universal gas constant [J/(K mol)]
+            system = obj.chemicalSystem;
+            propertiesMatrix = system.propertiesMatrix; % Properties matrix
+            
+            % Unpack propertiesMatrix
+            Ni = propertiesMatrix(:, system.ind_ni); % [mol]
+            obj.hf = dot(propertiesMatrix(:, system.ind_hfi), Ni); % [J]
+            obj.h = dot(propertiesMatrix(:, system.ind_hi), Ni); % [J]
+            obj.ef = dot(propertiesMatrix(:, system.ind_efi), Ni); % [J]
+            obj.cp = dot(propertiesMatrix(:, system.ind_cpi), Ni); % [J/K]
+            obj.s0 = dot(propertiesMatrix(:, system.ind_si), Ni); % [J/K]
+
+            % Compute total composition of gas species [mol]
+            N_gas = sum(Ni(~obj.phase));
+
+            % Get non zero species
+            FLAG_NONZERO = obj.Xi > 0;
             
             % Compute volume [m3]
             if N_gas
@@ -1019,9 +1002,9 @@ classdef Mixture < handle & matlab.mixin.Copyable
                 % Set temperature-dependent matrix properties to zero
                 mixFuel.chemicalSystem.clean();
                 % Fill properties matrix with only fuel species
-                mixFuel.chemicalSystem.setPropertiesMatrix(obj.listSpeciesFuel, obj.molesFuel, obj.T);
-                % Compute thermodynamic properties 
-                mixFuel.computeProperties();
+                mixFuel.chemicalSystem.setPropertiesMatrixComposition(obj.listSpeciesFuel, obj.molesFuel);
+                % Compute composition properties 
+                mixFuel.computeComposition();
                 % Assign values elements C, H, O, N, S, and Si
                 obj.assignAtomElementsFuel(mixFuel.natomElements);
                 % Compute theoretical moles of the oxidizer of reference for a stoichiometric combustion
@@ -1060,7 +1043,7 @@ classdef Mixture < handle & matlab.mixin.Copyable
             % Set temperature-dependent matrix properties to zero
             system.clean();
             % Fill properties matrix with only oxidizer species
-            system.setPropertiesMatrix(obj.listSpeciesOxidizer, obj.molesOxidizer, obj.T);
+            system.setPropertiesMatrixComposition(obj.listSpeciesOxidizer, obj.molesOxidizer);
             % Assign propertiesMatrixOxidizer
             obj.chemicalSystem.propertiesMatrixOxidizer = system.propertiesMatrix;
         end

--- a/+combustiontoolbox/+core/@Species/getGibbsEnergy.m
+++ b/+combustiontoolbox/+core/@Species/getGibbsEnergy.m
@@ -3,15 +3,14 @@ function g0 = getGibbsEnergy(obj, T)
     % using piecewise cubic Hermite interpolating polynomials and linear extrapolation
     %
     % Args:
-    %     species (char): Chemical species
+    %     obj (Species): Species object
     %     T (float): Temperature [K]
-    %     DB (struct): Database with custom thermodynamic polynomials functions generated from NASAs 9 polynomials fits
     %
     % Returns:
     %     g0 (float): Gibbs energy in molar basis [J/mol]
     %
     % Example:
-    %     g0 = getGibbsEnergy('H2O', 298.15, DB)
+    %     g0 = getGibbsEnergy(obj, 300)
     
     persistent cachedSpecies;
     persistent cachedG0curves;

--- a/+combustiontoolbox/+equilibrium/@EquilibriumSolver/EquilibriumSolver.m
+++ b/+combustiontoolbox/+equilibrium/@EquilibriumSolver/EquilibriumSolver.m
@@ -199,7 +199,7 @@ classdef EquilibriumSolver < handle
             %     mixArray (Mixture): Array of Mixture objects updated with equilibrium compositions and properties
             %
             % Example:
-            %     * mixArray = solveArray(EquilibriumSolver(), mixArray);
+            %     mixArray = solveArray(EquilibriumSolver(), mixArray);
             
             % Definitions
             n = length(mixArray);

--- a/+combustiontoolbox/+equilibrium/@EquilibriumSolver/equilibrateT.m
+++ b/+combustiontoolbox/+equilibrium/@EquilibriumSolver/equilibrateT.m
@@ -41,6 +41,13 @@ function mix2 = equilibrateT(obj, mix1, mix2, T, varargin)
     % Unpack addtitional inputs
     if nargin > 4
         molesGuess = varargin{1};
+        
+        if system.FLAG_COMPLETE
+            molesGuess = [];
+        elseif ~isempty(molesGuess)
+            molesGuess = molesGuess(system.indexProducts);
+        end
+
     end
 
     % Check flag
@@ -128,7 +135,6 @@ function mix2 = equilibrateTPerfect(mix1, mix2, T)
     
     % Import packages
     import combustiontoolbox.common.Units
-    import combustiontoolbox.common.Constants
 
     % Definitions
     Tref = 298.15; % [K] To be fixed: each species should have its own reference temperature

--- a/+combustiontoolbox/+equilibrium/@EquilibriumSolver/equilibrateT.m
+++ b/+combustiontoolbox/+equilibrium/@EquilibriumSolver/equilibrateT.m
@@ -147,7 +147,7 @@ function mix2 = equilibrateTPerfect(mix1, mix2, T)
     mix2.cv = mix1.cv;
     mix2.gamma = mix1.gamma;
     mix2.gamma_s = mix1.gamma_s;
-    mix2.sound = sqrt(mix2.gamma * Units.convert(mix2.p, 'bar', 'Pa') / mix2.rho);
+    mix2.sound = sqrt(mix2.gamma * mix2.p * Units.bar2Pa / mix2.rho);
 
     % Compute enthalpy [J]
     mix2.hf = mix1.hf;

--- a/+combustiontoolbox/+equilibrium/@EquilibriumSolver/equilibrateT.m
+++ b/+combustiontoolbox/+equilibrium/@EquilibriumSolver/equilibrateT.m
@@ -102,7 +102,7 @@ end
 function pP = computePressure(mix, T, moles, system)
     % Compute pressure [bar] of product mixture
     vMolar = vSpecific2vMolar(mix, mix.vSpecific, moles, sum(moles(system.indexGas)), [system.indexGas, system.indexCondensed]);
-    pP = mix.equationOfState.getPressure(T, vMolar, system.listSpecies, mix.Xi) * 1e-5;
+    pP = mix.equationState.getPressure(T, vMolar, system.listSpecies, mix.Xi) * 1e-5;
 end
 
 function vector = reshapeVector(system, index, indexModified, vectorModified)

--- a/+combustiontoolbox/+equilibrium/@EquilibriumSolver/equilibriumGibbs.m
+++ b/+combustiontoolbox/+equilibrium/@EquilibriumSolver/equilibriumGibbs.m
@@ -101,7 +101,7 @@ function [N, dNi_T, dN_T, dNi_p, dN_p, index, STOP, STOP_ions, h0] = equilibrium
     J22 = zeros(NS - NG + 1);
     A0_T = A0';
 
-    % Initialize composition matrix N [mol, FLAG_CONDENSED]
+    % Initialize composition vector N
     [N, NP] = obj.equilibriumGuess(N, NP, A0_T(indexElements, index0), muRT(index0), NatomE, index0, indexGas_0, indexIons, NG, molesGuess);
 
     % Initialization 

--- a/+combustiontoolbox/+rocket/@RocketSolver/rocketFAC.m
+++ b/+combustiontoolbox/+rocket/@RocketSolver/rocketFAC.m
@@ -26,6 +26,9 @@ function [mix1, mix2_inj, mix2_c, mix3, mix4] = rocketFAC(obj, mix1, varargin)
     % Example:
     %     [mix2_inj, mix2_c, mix3] = rocketFAC(obj, mix1, mix2_inj, mix2_c, mix3)
     
+    % Import packages
+    import combustiontoolbox.common.Units
+    
     % Definitions
     mix2_inj = copy(mix1);
     areaRatio = mix1.areaRatio;
@@ -73,7 +76,7 @@ function [mix1, mix2_inj, mix2_c, mix3, mix4] = rocketFAC(obj, mix1, varargin)
 
     % Initialization
     STOP = 1; it = 0;
-    pressure_inj = convert_bar_to_Pa(pressure_inj); % [Pa]
+    pressure_inj = pressure_inj * Units.bar2Pa; % [Pa]
     mix2_inf_guess = mix2_inj;
     temp_mix1.areaRatio = areaRatioChamber;
     
@@ -89,7 +92,7 @@ function [mix1, mix2_inj, mix2_c, mix3, mix4] = rocketFAC(obj, mix1, varargin)
         [~, mix2_inf, mix3, mix2_c] = rocketIAC(obj, temp_mix1, mix2_inf_guess, mix3_guess, mix2_c_guess, false);
 
         % Get results
-        pressure_c = convert_bar_to_Pa(mix2_c.p); % [Pa]
+        pressure_c = mix2_c.p * Units.bar2Pa; % [Pa]
         density_c = mix2_c.rho; % [kg/m3]
         velocity_c = mix2_c.u; % [m/s]
 

--- a/+combustiontoolbox/+shockdetonation/@DetonationSolver/detonationCJ.m
+++ b/+combustiontoolbox/+shockdetonation/@DetonationSolver/detonationCJ.m
@@ -30,14 +30,14 @@ function [mix1, mix2] = detonationCJ(obj, mix1, varargin)
     
     % Solve Chapman-Jouguet detonation
     try
-        [T2, p2, STOP, it, T_guess, p2_guess] = solve_cj_detonation(FLAG_FAST); % p2 [Pa]
+        [T2, p2, STOP, it, T_guess, p2_guess] = solve_cj_detonation(FLAG_FAST);
         assert(STOP < obj.tol0);
     catch
         % If solution has not converged, repeat without composition estimate
         fprintf('Recalculating: %.2f [K]\n', T2);
         guess_moles = [];
         FLAG_FAST = false;
-        [T2, p2, STOP, it, T_guess, p2_guess] = solve_cj_detonation(FLAG_FAST); % p2 [Pa]
+        [T2, p2, STOP, it, T_guess, p2_guess] = solve_cj_detonation(FLAG_FAST);
     end
 
     % Check convergence
@@ -70,9 +70,9 @@ function [mix1, mix2] = detonationCJ(obj, mix1, varargin)
             % Apply correction
             [log_p2p1, log_T2T1] = apply_correction(x, p2p1, T2T1, lambda);
             % Apply antilog
-            [p2, T2] = apply_antilog(mix1, log_p2p1, log_T2T1); % [Pa] and [K]
+            [p2, T2] = apply_antilog(mix1, log_p2p1, log_T2T1); % [bar] and [K]
             % Update ratios
-            p2p1 = p2 / (convert_bar_to_Pa(mix1.p));
+            p2p1 = p2 / mix1.p;
             T2T1 = T2 / mix1.T;
             % Compute STOP criteria
             STOP = compute_STOP(x);
@@ -101,12 +101,12 @@ function [p2, T2, p2p1, T2T1, STOP] = get_guess(obj, mix1, mix2)
     if mix1.T == mix2.T
         [p2p1, T2T1, STOP] = detonationGuess(obj, mix1);
 
-        p2 = p2p1 * convert_bar_to_Pa(mix1.p); % [Pa]
+        p2 = p2p1 * mix1.p; % [bar]
         T2 = T2T1 * mix1.T; % [K]
     else
-        p2 = convert_bar_to_Pa(mix2.p); % [Pa]
+        p2 = mix2.p; % [bar]
         T2 = mix2.T; % [K]
-        p2p1 = p2 / (convert_bar_to_Pa(mix1.p));
+        p2p1 = p2 / mix1.p;
         T2T1 = T2 / mix1.T;
         STOP = 1;
     end
@@ -125,28 +125,30 @@ end
 function [J, b, guess_moles] = update_system(equilibriumSolver, mix1, mix2, p2, T2, R0, guess_moles, FLAG_FAST)
     % Update Jacobian matrix and vector b
     r1 = mix1.rho; % [kg/m3]
-    p1 = convert_bar_to_Pa(mix1.p); % [Pa]
+    p1 = mix1.p; % [bar]
     h1 = mix1.h / mix1.mi; % [J/kg]
     
     % Set pressure and temperature of mix2
-    mix2.p = convert_Pa_to_bar(p2); mix2.T = T2;
+    mix2.p = p2; mix2.T = T2;
 
     % Calculate frozen state given T & p
     [mix2, r2, dVdT_p, dVdp_T] = state(equilibriumSolver, mix1, mix2, guess_moles);
 
+    r2r1 = r2 / r1; % [-]
+    p1p2 = p1 / p2; % [-]
     W2 = mix2.W; % [kg/mol]
     h2 = mix2.h / mix2.mi; % [J/kg]
     cp2 = mix2.cp / mix2.mi; % [J/(K-kg)]
     gamma2_s = mix2.gamma_s; % [-]
 
-    J1 = p1 / p2 + r2 / r1 * gamma2_s * dVdp_T;
-    J2 = r2 / r1 * gamma2_s * dVdT_p;
-    b1 = p1 / p2 - 1 + gamma2_s * (r2 / r1 - 1);
+    J1 = p1p2 + r2r1 * gamma2_s * dVdp_T;
+    J2 = r2r1 * gamma2_s * dVdT_p;
+    b1 = p1p2 - 1 + gamma2_s * (r2r1 - 1);
 
-    J3 = gamma2_s * T2 / (2 * W2) * ((r2 / r1)^2 - 1 - dVdp_T * (1 + (r2 / r1)^2)) ...
+    J3 = gamma2_s * T2 / (2 * W2) * (r2r1^2 - 1 - dVdp_T * (1 + r2r1^2)) ...
         + T2 / W2 * (dVdT_p - 1);
-    J4 = -gamma2_s * T2 / (2 * W2) * ((r2 / r1)^2 + 1) * dVdT_p - T2 * cp2 / R0;
-    b2 = (h2 - h1) / R0 - gamma2_s * T2 / (2 * W2) * ((r2 / r1)^2 - 1);
+    J4 = - gamma2_s * T2 / (2 * W2) * (r2r1^2 + 1) * dVdT_p - T2 * cp2 / R0;
+    b2 = (h2 - h1) / R0 - gamma2_s * T2 / (2 * W2) * (r2r1^2 - 1);
 
     J = [J1 J2; J3 J4];
     b = [b1; b2];
@@ -182,8 +184,8 @@ end
 
 function [p2, T2] = apply_antilog(mix1, log_p2p1, log_T2T1)
     % compute p2 and T2
-    p2 = exp(log_p2p1) * convert_bar_to_Pa(mix1.p); % [Pa]
-    T2 = exp(log_T2T1) * mix1.T;
+    p2 = exp(log_p2p1) * mix1.p; % [bar]
+    T2 = exp(log_T2T1) * mix1.T; % [K]
 end
 
 function STOP = compute_STOP(x)

--- a/+combustiontoolbox/+shockdetonation/@DetonationSolver/detonationReflected.m
+++ b/+combustiontoolbox/+shockdetonation/@DetonationSolver/detonationReflected.m
@@ -69,9 +69,9 @@ function [mix1, mix2, mix5] = detonationReflected(obj, mix1, mix2, varargin)
             % Apply correction
             [log_p5p2, log_T5T2] = apply_correction(x, p5p2, T5T2, lambda);
             % Apply antilog
-            [p5, T5] = apply_antilog(mix2, log_p5p2, log_T5T2); % [Pa] and [K]
+            [p5, T5] = apply_antilog(mix2, log_p5p2, log_T5T2); % [bar] and [K]
             % Update ratios
-            p5p2 = p5 / (convert_bar_to_Pa(mix2.p));
+            p5p2 = p5 / mix2.p;
             T5T2 = T5 / mix2.T;
             % Compute STOP criteria
             STOP = compute_STOP(x);
@@ -102,13 +102,13 @@ function [p5, T5, p5p2, T5T2] = get_guess(mix2, mix5)
         b = (mix2.gamma_s + 1) / (mix2.gamma_s - 1);
         p5p2 = 0.5 * (b + sqrt(8 + b^2)); % positive root of (7.45 - report CEA)
 
-        p5 = p5p2 * convert_bar_to_Pa(mix2.p); % [Pa]
+        p5 = p5p2 * mix2.p; % [bar]
         T5 = T5T2 * mix2.T; % [K]
     else
-        p5 = convert_bar_to_Pa(mix5.p); % [Pa]
+        p5 = mix5.p; % [bar]
         T5 = mix5.T; % [K]
 
-        p5p2 = p5 / (convert_bar_to_Pa(mix2.p));
+        p5p2 = p5 / mix2.p;
         T5T2 = T5 / mix2.T;
     end
 
@@ -117,30 +117,32 @@ end
 function [J, b, guess_moles] = update_system(equilibriumSolver, mix2, mix5, p5, T5, R0, guess_moles, FLAG_FAST)
     % Update Jacobian matrix and vector b
     r2 = mix2.rho; % [kg/m3]
-    p2 = convert_bar_to_Pa(mix2.p); % [Pa]
+    p2 = mix2.p; % [bar]
     T2 = mix2.T; % [K]
     u2 = mix2.u; % [m/s]
     W2 = mix2.W; % [kg/mol]
     h2 = mix2.h / mix2.mi; % [J/kg]
 
     % Set pressure and temperature of mix5
-    mix5.p = convert_Pa_to_bar(p5); mix5.T = T5;
+    mix5.p = p5; mix5.T = T5;
 
     % Calculate state given T & p
     [mix5, r5, dVdT_p, dVdp_T] = state(equilibriumSolver, mix2, mix5, guess_moles);
 
+    r5r2 = r5 / r2; % [-]
+    p5p2 = p5 / p2; % [-]
     W5 = mix5.W; % [kg/mol]
     h5 = mix5.h / mix5.mi; % [J/kg]
     cp5 = mix5.cp / mix5.mi; % [J/(K-kg)]
 
     alpha = (W2 * u2^2) / (R0 * T2);
-    J1 = (r5 / r2) / (r5 / r2 - 1)^2 * alpha * dVdp_T - p5 / p2;
-    J2 = (r5 / r2) / (r5 / r2 - 1)^2 * alpha * dVdT_p;
-    b1 = p5 / p2 - 1 - alpha * r5 / r2 / (r5 / r2 - 1);
+    J1 = r5r2 / (r5r2 - 1)^2 * alpha * dVdp_T - p5p2;
+    J2 = r5r2 / (r5r2 - 1)^2 * alpha * dVdT_p;
+    b1 = p5p2 - 1 - alpha * r5r2 / (r5r2 - 1);
 
-    J3 = u2^2 / R0 * (r5 / r2) / (r5 / r2 - 1)^2 * dVdp_T + T5 / W5 * (dVdT_p - 1);
-    J4 = u2^2 / R0 * (r5 / r2) / (r5 / r2 - 1)^2 * dVdT_p - T5 * cp5 / R0;
-    b2 = (h5 - h2) / R0 - u2^2 / (2 * R0) * (r5 / r2 + 1) / (r5 / r2 - 1);
+    J3 = u2^2 / R0 * r5r2 / (r5r2 - 1)^2 * dVdp_T + T5 / W5 * (dVdT_p - 1);
+    J4 = u2^2 / R0 * r5r2 / (r5r2 - 1)^2 * dVdT_p - T5 * cp5 / R0;
+    b2 = (h5 - h2) / R0 - u2^2 / (2 * R0) * (r5r2 + 1) / (r5r2 - 1);
 
     J = [J1 J2; J3 J4];
     b = [b1; b2];
@@ -176,8 +178,8 @@ end
 
 function [p5, T5] = apply_antilog(mix2, log_p5p2, log_T5T2)
     % compute p2 and T2
-    p5 = exp(log_p5p2) * convert_bar_to_Pa(mix2.p); % [Pa]
-    T5 = exp(log_T5T2) * mix2.T;
+    p5 = exp(log_p5p2) * mix2.p; % [bar]
+    T5 = exp(log_T5T2) * mix2.T; % [K]
 end
 
 function STOP = compute_STOP(x)
@@ -186,7 +188,7 @@ function STOP = compute_STOP(x)
 end
 
 function mix5 = save_state(mix2, mix5, STOP)
-    mix5.u = convert_bar_to_Pa(mix5.p - mix2.p) / (mix2.u * mix2.rho) - mix2.u;
+    mix5.u = combustiontoolbox.common.Units.bar2Pa * (mix5.p - mix2.p) / (mix2.u * mix2.rho) - mix2.u;
     mix5.uShock = mix2.u * mix2.rho / mix5.rho;
     mix5.mach = mix5.uShock / mix5.sound;
     mix5.errorProblem = STOP;

--- a/+combustiontoolbox/+shockdetonation/@ShockSolver/shockIncident.m
+++ b/+combustiontoolbox/+shockdetonation/@ShockSolver/shockIncident.m
@@ -79,9 +79,9 @@ function [mix1, mix2] = shockIncident(obj, mix1, u1, varargin)
             % Apply correction
             [log_p2p1, log_T2T1] = apply_correction(x, p2p1, T2T1, lambda);
             % Apply antilog
-            [p2, T2] = apply_antilog(mix1, log_p2p1, log_T2T1); % [Pa] and [K]
+            [p2, T2] = apply_antilog(mix1, log_p2p1, log_T2T1); % [bar] and [K]
             % Update ratios
-            p2p1 = p2 / (convert_bar_to_Pa(mix1.p));
+            p2p1 = p2 / mix1.p;
             T2T1 = T2 / mix1.T;
             % Compute STOP criteria
             aux = compute_STOP(x);
@@ -143,12 +143,12 @@ function [p2, T2, p2p1, T2T1] = get_guess(obj, mix1, mix2)
             T2 = T2T1 * mix1.T; % [K]
         end
 
-        p2 = p2p1 * convert_bar_to_Pa(mix1.p); % [Pa]
+        p2 = p2p1 * mix1.p; % [bar]
     else
-        p2 = convert_bar_to_Pa(mix2.p); % [Pa]
+        p2 = mix2.p; % [bar]
         T2 = mix2.T; % [K]
 
-        p2p1 = p2 / convert_bar_to_Pa(mix1.p);
+        p2p1 = p2 / mix1.p;
         T2T1 = T2 / mix1.T;
     end
     
@@ -157,30 +157,32 @@ end
 function [J, b, guess_moles] = update_system(equilibriumSolver, mix1, mix2, p2, T2, R0, guess_moles, FLAG_FAST)
     % Update Jacobian matrix and vector b
     r1 = mix1.rho; % [kg/m3]
-    p1 = convert_bar_to_Pa(mix1.p); % [Pa]
+    p1 = mix1.p; % [bar]
     T1 = mix1.T; % [K]
     u1 = mix1.u; % [m/s]
     W1 = mix1.W; % [kg/mol]
     h1 = mix1.h / mix1.mi; % [J/kg]
     
     % Set pressure and temperature of mix2
-    mix2.p = convert_Pa_to_bar(p2); mix2.T = T2;
+    mix2.p = p2; mix2.T = T2;
 
     % Calculate state given T & p
     [mix2, r2, dVdT_p, dVdp_T] = state(equilibriumSolver, mix1, mix2, guess_moles);
     
+    r1r2 = r1 / r2; % [-]
+    p2p1 = p2 / p1; % [-]
     W2 = mix2.W; % [kg/mol]
     h2 = mix2.h / mix2.mi; % [J/kg]
     cp2 = mix2.cp / mix2.mi; % [J/(K-kg)]
 
     alpha = (W1 * u1^2) / (R0 * T1);
-    J1 = -r1 / r2 * alpha * dVdp_T - p2 / p1;
-    J2 = -r1 / r2 * alpha * dVdT_p;
-    b1 = p2 / p1 - 1 + alpha * (r1 / r2 - 1);
+    J1 = -r1r2 * alpha * dVdp_T - p2p1;
+    J2 = -r1r2 * alpha * dVdT_p;
+    b1 = p2p1 - 1 + alpha * (r1 / r2 - 1);
 
-    J3 = -u1^2 / R0 * (r1 / r2)^2 * dVdp_T + T2 / W2 * (dVdT_p - 1);
-    J4 = -u1^2 / R0 * (r1 / r2)^2 * dVdT_p - T2 * cp2 / R0;
-    b2 = (h2 - h1) / R0 - u1^2 / (2 * R0) * (1 - (r1 / r2)^2);
+    J3 = -u1^2 / R0 * r1r2^2 * dVdp_T + T2 / W2 * (dVdT_p - 1);
+    J4 = -u1^2 / R0 * r1r2^2 * dVdT_p - T2 * cp2 / R0;
+    b2 = (h2 - h1) / R0 - u1^2 / (2 * R0) * (1 - r1r2^2);
 
     J = [J1 J2; J3 J4];
     b = [b1; b2];
@@ -216,8 +218,8 @@ end
 
 function [p2, T2] = apply_antilog(mix1, log_p2p1, log_T2T1)
     % compute p2 and T2
-    p2 = exp(log_p2p1) * convert_bar_to_Pa(mix1.p); % [Pa]
-    T2 = exp(log_T2T1) * mix1.T;
+    p2 = exp(log_p2p1) * mix1.p; % [bar]
+    T2 = exp(log_T2T1) * mix1.T; % [K]
 end
 
 function STOP = compute_STOP(x)

--- a/+combustiontoolbox/+utils/+display/@PlotConfig/PlotConfig.m
+++ b/+combustiontoolbox/+utils/+display/@PlotConfig/PlotConfig.m
@@ -77,10 +77,10 @@ classdef PlotConfig < handle
         id_polar1 = 1001                      % Axes id for pressure-deflection polar diagrams
         id_polar2 = 1002                      % Axes id for wave-deflection polar diagrams
         id_polar3 = 1003                      % Axes id for velocity polar diagrams
-        displaySpecies
-        mintolDisplay = 1e-6
-        plotProperties = {'T', 'p', 'rho', 'h', 'e', 'g', 'cp', 's', 'gamma_s', 'sound'}
-        plotPropertiesBasis = {[], [], [], 'mi', 'mi', 'mi', 'mi', 'mi', [], []}
+        displaySpecies                        % Display species
+        mintolDisplay = 1e-6                  % Minimum tolerance to display species
+        plotProperties = {'T', 'p', 'rho', 'h', 'e', 'g', 'cp', 's', 'gamma_s', 'sound'} % Plot properties
+        plotPropertiesBasis = {[], [], [], 'mi', 'mi', 'mi', 'mi', 'mi', [], []} % Plot properties basis
     end
 
     properties (Dependent)


### PR DESCRIPTION
## **Summary**  
This pull request refactors the `Mixture` class to improve maintainability, streamline thermodynamic computations, and simplify mixture initialization. Additionally, it includes various optimizations in the `ChemicalSystem` and `Units` classes, as well as corrections in shock and detonation solvers.  

## **Key changes**
 
### **Refactoring of `Mixture` Class**  [#1030]
- **Separation of Composition and Thermodynamic Updates:**  
  - Introduced `updateComposition()` to handle mixture composition independently.  
  - Introduced `updateThermodynamics()` to compute thermodynamic properties without redundant recalculations.  
- **Simplified Equivalence Ratio Handling:**  
  - The process of defining a mixture using the equivalence ratio is now more structured and avoids unnecessary recalculations.  
- **Optimized State-Setting Methods:**  
  - `setTemperature()`, `setPressure()`, and `setVolume()` now only trigger necessary updates, avoiding redundant logic.  

### **Optimizations and Fixes in Supporting Classes**  
- **`ChemicalSystem` Class**  
  - **Update:** Avoid `get` methods for `indexElements` (used in equivalence ratio computation) and `indexSpecies` to reduce overhead.  

- **`Units` Class**  
  - **Update:** Removed unnecessary handle functions, replacing them with direct conversion factors for improved efficiency.  
  - **Update:** Ensured direct conversion factors are used instead of `convert` method (better performance).  

- **Performance Improvement in `Mixture` Class**  
  - **Update:** Undid previous commit in `assignAtomElementsFuel()` as it was causing performance degradation.  
  - **Update:** Incorporated direct conversion factors when interacting with the `Units` class to further optimize calculations.  

### **Shock and Detonation Solvers**  
- **Update:** Removed unnecessary unit conversions and simplified calculations to enhance performance and accuracy.  

## **Bug Fixes**  
- **Solve:** Fixed an issue with `molesGuess` where incorrect behavior occurred when `indexProducts` differed from `indexSpecies`.  
